### PR TITLE
fix: update to Node.js 22

### DIFF
--- a/cdk/BackendStack.ts
+++ b/cdk/BackendStack.ts
@@ -44,7 +44,7 @@ export class BackendStack extends Stack {
 				hash: layer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const getWaterLevels = new PackedLambdaFn(


### PR DESCRIPTION
See https://aws.amazon.com/de/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/
